### PR TITLE
InsertIdentity contract event

### DIFF
--- a/src/contracts/sol/Semacaulk.sol
+++ b/src/contracts/sol/Semacaulk.sol
@@ -32,6 +32,9 @@ contract Semacaulk is KeccakMT, BN254 {
     // Custom errors
     error RootMismatch(bytes32 _generatedRoot);
 
+    // Events
+    event InsertIdentity(uint256 indexed _index, uint256 indexed _identityCommitment);
+
     constructor(
         bytes32 _lagrangeTreeRoot,
         uint256 _accumulatorX,
@@ -50,11 +53,12 @@ contract Semacaulk is KeccakMT, BN254 {
         uint256 _lagrangeLeafY,
         bytes32[] memory _lagrangeMerkleProof
     ) public {
+        uint256 index = currentIndex;
         bytes32 lagrangeLeaf = keccak256(abi.encodePacked(_lagrangeLeafX, _lagrangeLeafY));
 
         // 1. Verify that _lagrangeLeaf exists in the lagrange tree at index currentIndex
         bytes32 generatedRoot = genRootFromPath(
-            currentIndex,
+            index,
             lagrangeLeaf,
             _lagrangeMerkleProof
         );
@@ -76,7 +80,9 @@ contract Semacaulk is KeccakMT, BN254 {
         accumulator = plus(accumulator, newPoint);
 
         // Increment the index
-        currentIndex += 1;
+        currentIndex = index + 1;
+
+        emit InsertIdentity(index, _identityCommitment);
     }
 
     function verifyTranscript() public pure returns(uint256, uint256) {

--- a/src/contracts/tests.rs
+++ b/src/contracts/tests.rs
@@ -201,7 +201,12 @@ pub async fn test_semacaulk_insert() {
             .unwrap()
             .expect("no receipt found");
 
-        //println!("{:?}", result);
+        let event_index = result.logs[0].topics[1];
+        let mut index_slice = [0u8; 32];
+        index_slice[31] = index as u8;
+
+        assert_eq!(index < 256, true);
+        assert_eq!(hex::encode(index_slice), hex::encode(event_index));
         assert_eq!(result.status.unwrap(), ethers::types::U64::from(1));
 
         println!(


### PR DESCRIPTION
`insertIdentity()`  now emits an event with the index and identity commitment.