### PR TITLE
Bind each proof to the signal hash by committing to all public inputs, including the signal hash, in the transcript

### DIFF
--- a/src/contracts/sol/tests/TestVerifier.sol
+++ b/src/contracts/sol/tests/TestVerifier.sol
@@ -11,9 +11,14 @@ contract TestVerifier is Verifier {
         Types.Proof memory proof,
         Types.G1Point memory accumulator,
         uint256 externalNullifier,
-        uint256 nullifierHash
+        uint256 nullifierHash,
+        uint256 signalHash
     ) public view {
-        verify(proof, accumulator, externalNullifier, nullifierHash);
+        uint256[3] memory publicInputs;
+        publicInputs[0] = externalNullifier;
+        publicInputs[1] = nullifierHash;
+        publicInputs[2] = signalHash;
+        verify(proof, accumulator, publicInputs);
     }
 
     function testBatchInvert(

--- a/src/contracts/tests/verifier.rs
+++ b/src/contracts/tests/verifier.rs
@@ -37,6 +37,7 @@ pub async fn test_semacaulk_verifier() {
     let identity_nullifier = Fr::from(123u64);
     let identity_trapdoor = Fr::from(456u64);
     let external_nullifier = Fr::from(789u64);
+    let signal_hash = Fr::from(888u64);
 
     let nullifier_hash =
         mimc7.multi_hash(&[identity_nullifier, external_nullifier], Fr::zero());
@@ -71,9 +72,10 @@ pub async fn test_semacaulk_verifier() {
 
     let accumulator = commit(&pk.srs_g1, &c).into_affine();
     let public_input = PublicData::<Bn254> {
-        accumulator: accumulator,
+        accumulator,
         external_nullifier,
         nullifier_hash,
+        signal_hash,
     };
 
     let proof = Prover::prove(
@@ -93,6 +95,7 @@ pub async fn test_semacaulk_verifier() {
         accumulator,
         external_nullifier,
         nullifier_hash,
+        signal_hash,
     );
 
     assert_eq!(is_valid, true);
@@ -108,8 +111,11 @@ pub async fn test_semacaulk_verifier() {
             x: f_to_u256(accumulator.x),
             y: f_to_u256(accumulator.y),
         },
-        f_to_u256(external_nullifier),
-        f_to_u256(nullifier_hash),
+        [
+            f_to_u256(external_nullifier),
+            f_to_u256(nullifier_hash),
+            f_to_u256(signal_hash),
+        ],
     ).send()
      .await
      .unwrap()

--- a/src/prover/mod.rs
+++ b/src/prover/mod.rs
@@ -147,5 +147,6 @@ pub struct ProvingKey<E: PairingEngine> {
 pub struct PublicData<E: PairingEngine> {
     pub(crate) accumulator: E::G1Affine,
     pub(crate) external_nullifier: E::Fr,
+    pub(crate) signal_hash: E::Fr,
     pub(crate) nullifier_hash: E::Fr,
 }

--- a/src/prover/prover.rs
+++ b/src/prover/prover.rs
@@ -141,7 +141,9 @@ impl Prover {
         let mut state = Self::init(pk, witness, assignment, public_input, precomputed, table_size);
         let mut transcript = Transcript::new_transcript();
 
-        // TODO: append public data
+        transcript.update_with_u256(public_input.external_nullifier);
+        transcript.update_with_u256(public_input.nullifier_hash);
+        transcript.update_with_u256(public_input.signal_hash);
 
         let (w0, key, w1, w2) = Self::assignment_round(&mut state);
 
@@ -197,6 +199,9 @@ impl Prover {
 
         // Sanity check multiopen_proof
         let mut transcript = Transcript::new_transcript();
+        transcript.update_with_u256(public_input.external_nullifier);
+        transcript.update_with_u256(public_input.nullifier_hash);
+        transcript.update_with_u256(public_input.signal_hash);
         transcript.update_with_g1(&w0);
         transcript.update_with_g1(&key);
         transcript.update_with_g1(&w1);

--- a/src/tests/prover_and_verifier.rs
+++ b/src/tests/prover_and_verifier.rs
@@ -26,6 +26,7 @@ pub fn test_prover_and_verifier() {
     let identity_nullifier = Fr::from(100u64);
     let identity_trapdoor = Fr::from(200u64);
     let external_nullifier = Fr::from(300u64);
+    let signal_hash = Fr::from(888u64);
 
     let nullifier_hash =
         mimc7.multi_hash(&[identity_nullifier, external_nullifier], Fr::zero());
@@ -63,6 +64,7 @@ pub fn test_prover_and_verifier() {
         accumulator: accumulator,
         external_nullifier,
         nullifier_hash,
+        signal_hash,
     };
 
     let proof = Prover::prove(
@@ -82,6 +84,7 @@ pub fn test_prover_and_verifier() {
         accumulator,
         external_nullifier,
         nullifier_hash,
+        signal_hash,
     );
 
     assert_eq!(is_valid, true);

--- a/src/verifier/mod.rs
+++ b/src/verifier/mod.rs
@@ -19,10 +19,15 @@ impl Verifier {
         accumulator: G1Affine,
         external_nullifier: Fr,
         nullifier_hash: Fr,
+        signal_hash: Fr,
     ) -> bool {
         let mut transcript = Transcript::new_transcript();
 
-        // Derive challenges
+        // Update transcript and derive challenges
+        transcript.update_with_u256(external_nullifier);
+        transcript.update_with_u256(nullifier_hash);
+        transcript.update_with_u256(signal_hash);
+
         transcript.update_with_g1(&proof.commitments.w0);
         transcript.update_with_g1(&proof.commitments.key);
         transcript.update_with_g1(&proof.commitments.w1);


### PR DESCRIPTION
- Introduces a signal hash public input
- Binds each proof to the signal hash by committing it to the transcript
- Also commits to the external nullifier and nullifier hash to the transcript